### PR TITLE
Update Podspec to fix missing import

### DIFF
--- a/react-native-amplitude-analytics.podspec
+++ b/react-native-amplitude-analytics.podspec
@@ -14,5 +14,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m}"
   s.platform = :ios, "8.0"
 
+  s.dependency "React"
+  
   s.dependency "Amplitude-iOS", "~> 3.14.1"
 end


### PR DESCRIPTION
#if __has_include(<React/RCTBridgeModule.h>)
#import <React/RCTBridgeModule.h>
#else
#import "RCTBridgeModule.h"
#endif