### PR TITLE
Adds Carthage support

### DIFF
--- a/ios/RNAmplitudeSDK.xcodeproj/project.pbxproj
+++ b/ios/RNAmplitudeSDK.xcodeproj/project.pbxproj
@@ -197,7 +197,10 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "${inherited}";
+				FRAMEWORK_SEARCH_PATHS = (
+					"${inherited}",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../ios/Pods/Amplitude-iOS",
@@ -219,7 +222,10 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "${inherited}";
+				FRAMEWORK_SEARCH_PATHS = (
+					"${inherited}",
+					"$(SRCROOT)/../../../ios/Carthage/Build/iOS",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../ios/Pods/Amplitude-iOS",


### PR DESCRIPTION
This PR adds support for projects using [Carthage](https://github.com/Carthage/Carthage) instead of Cocoapods

It adds the Carthage framework folder to FRAMEWORK_SEARCH_PATHS, similar to the Cocoapod folder in HEADER_SEARCH_PATHS