### PR TITLE
Can't find version 18 when building on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.18.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.amplitude:android-sdk:2.17.0'
 }


### PR DESCRIPTION
When building android I'm getting this error:
![image](https://user-images.githubusercontent.com/5445860/40379614-6fb3044a-5dab-11e8-876f-b5f44b39dcd1.png)

Not sure why we are referencing such an old version of react native, but changing it to simply be any version (`+`) allows me to build on Android