### PR TITLE
[ios] Update instructions & support for manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ After you do that make sure that:
 
 or
 
-- download the Amplitude-iOS sdk from [here](https://amplitude.zendesk.com/hc/en-us/articles/115002278527#installation) and add it to your project manually.
+- download the Amplitude-iOS sdk from [here](https://amplitude.zendesk.com/hc/en-us/articles/115002278527#installation) and add it to your project manually. Make sure the `Amplitude-iOS` directory of the SDK is included in the root of your app's ios folder.
 3. Run your project (`Cmd+R`)
 
 

--- a/ios/RNAmplitudeSDK.xcodeproj/project.pbxproj
+++ b/ios/RNAmplitudeSDK.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../ios/Pods/Amplitude-iOS",
+					"$(SRCROOT)/../../../ios/Amplitude-iOS",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
@@ -229,6 +230,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../ios/Pods/Amplitude-iOS",
+					"$(SRCROOT)/../../../ios/Amplitude-iOS",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",


### PR DESCRIPTION
The Header Search Path is currently only set up to have the SDK installed via Pods.  This adds support for putting the `Amplitude-iOS` SDK directory (with the `/Amplitude` and `/Amplitude.xcodeproj` subfolders) at the root level (instead of forcing Pods).