### PR TITLE
Add android support for react-native 0.60.x

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance: "new RNAmplitudeSDKPackage(this.getApplication())"
+      }
+    }
+  }
+};


### PR DESCRIPTION
React-native autolink required more info about how instance this android package. I add it in `react-native.config.js` to fix it.