### PR TITLE
add setEventUploadThreshold method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ class testApp extends Component {
   constructor() {
     super();
     const amplitude = new RNAmplitude('Your Amplitude key');
+
+    // set event upload threshold
+    amplitude.setEventUploadThreshold(30);
 	 
     // log an event
     amplitude.logEvent(eventName);

--- a/android/src/main/java/com/sudoplz/reactnativeamplitudeanalytics/RNAmplitudeSDK.java
+++ b/android/src/main/java/com/sudoplz/reactnativeamplitudeanalytics/RNAmplitudeSDK.java
@@ -44,6 +44,11 @@ public class RNAmplitudeSDK extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void setEventUploadThreshold(int threshold) {
+    Amplitude.getInstance().setEventUploadThreshold(threshold);
+  }
+
+  @ReactMethod
   public void setUserId(String id) {
     Amplitude.getInstance().setUserId(id);
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export default class Amplitude {
   // --------------------------------------------------
   // Identify
   // --------------------------------------------------
+  setEventUploadThreshold(threshold: number): void;
   setUserId(userId: string | number | null): void;
   setUserProperties(properties: Record<string, any>): void;
   setOptOut(optOut: boolean): void;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,15 @@ class Amplitude {
   // --------------------------------------------------
   // Identify
   // --------------------------------------------------
+
+  setEventUploadThreshold(threshold) {
+    if (amplitudeHasInitialized) {
+      return RNAmplitudeSDK.setEventUploadThreshold(threshold);
+    } else {
+      throw new Error('You called Amplitude.setEventUploadThreshold before initializing it. Run new Amplitute(key) first.');
+    }
+  }
+
   setUserId(userId) {
     if (amplitudeHasInitialized) {
       return RNAmplitudeSDK.setUserId(userId ? userId.toString() : null);

--- a/ios/AmplitudeSDK.m
+++ b/ios/AmplitudeSDK.m
@@ -11,6 +11,11 @@ RCT_EXPORT_METHOD(initialize:(NSString* )writeKey setTrackSessionEvents:(BOOL) t
      [[Amplitude instance] initializeApiKey: writeKey];
 }
 
+RCT_EXPORT_METHOD(setEventUploadThreshold:(int)threshold)
+{
+    [[Amplitude instance] setEventUploadThreshold:[NSNumber numberWithInt:threshold]];
+}
+
 RCT_EXPORT_METHOD(setUserId:(NSString *)userId)
 {
      [[Amplitude instance] setUserId:userId];


### PR DESCRIPTION
Add `setEventUploadThreshold` method
[iOS docs](http://amplitude.github.io/Amplitude-iOS/Classes/Amplitude.html#//api/name/eventUploadThreshold),
[Android docs](http://amplitude.github.io/Amplitude-Android/) (see `AmplitudeClient` -> `setEventUploadThreshold` - unfortunately no anchor for this method)