### PR TITLE
add append & prepend methods with string-only values

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ class testApp extends Component {
     // add to user property
     amplitude.addToUserProperty(property, amount)
 
+    // append to user property
+    amplitude.appendToUserProperty(property, 'stringValue')
+
+    // prepend to user property
+    amplitude.prependToUserProperty(property, 'stringValue')
+
     // set user property once
     amplitude.setUserPropertyOnce(property, value)
 

--- a/android/src/main/java/com/sudoplz/reactnativeamplitudeanalytics/RNAmplitudeSDK.java
+++ b/android/src/main/java/com/sudoplz/reactnativeamplitudeanalytics/RNAmplitudeSDK.java
@@ -121,7 +121,7 @@ public class RNAmplitudeSDK extends ReactContextBaseJavaModule {
       return;
     }
   }
-
+ 
   @ReactMethod
   public void logRevenue(String productIdentifier, int quantity, double amount) {
     Amplitude.getInstance().logRevenue(productIdentifier, quantity, amount);
@@ -240,4 +240,15 @@ public class RNAmplitudeSDK extends ReactContextBaseJavaModule {
     Amplitude.getInstance().identify(identify);
   }
 
+  @ReactMethod
+  public void appendToUserProperty(String property, String value) {
+    Identify identify = new Identify().append(property, value);
+    Amplitude.getInstance().identify(identify);
+  }
+
+  @ReactMethod
+  public void prependToUserProperty(String property, String value) {
+    Identify identify = new Identify().prepend(property, value);
+    Amplitude.getInstance().identify(identify);
+  }
 }

--- a/index.js
+++ b/index.js
@@ -187,7 +187,11 @@ class Amplitude {
 
   appendToUserProperty(property, value) {
     if (amplitudeHasInitialized) {
-      return RNAmplitudeSDK.appendToUserProperty(property, value);
+      if (typeof value === 'string') {
+        return RNAmplitudeSDK.appendToUserProperty(property, value);
+      } else {
+        throw new Error('Amplitude.appendToUserProperty only accepts string values .');
+      }
     } else {
       throw new Error('You called Amplitude.appendToUserProperty before initializing it. Run new Amplitute(key) first.');
     }
@@ -195,7 +199,11 @@ class Amplitude {
 
   prependToUserProperty(property, value) {
     if (amplitudeHasInitialized) {
-      return RNAmplitudeSDK.prependToUserProperty(property, value);
+      if (typeof value === 'string') {
+        return RNAmplitudeSDK.prependToUserProperty(property, value);
+      } else {
+        throw new Error('Amplitude.prependToUserProperty only accepts string values .');
+      }
     } else {
       throw new Error('You called Amplitude.prependToUserProperty before initializing it. Run new Amplitute(key) first.');
     }

--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ class Amplitude {
     if (amplitudeHasInitialized) {
       return RNAmplitudeSDK.addToUserProperty(property, amount);
     } else {
-      throw new Error('You called Amplitude.addToUserPropery before initializing it. Run new Amplitute(key) first.');
+      throw new Error('You called Amplitude.addToUserProperty before initializing it. Run new Amplitute(key) first.');
     }
   }
 
@@ -182,6 +182,22 @@ class Amplitude {
       return RNAmplitudeSDK.setUserPropertyOnce(property, value);
     } else {
       throw new Error('You called Amplitude.setUserPropertyOnce before initializing it. Run new Amplitute(key) first.');
+    }
+  }
+
+  appendToUserProperty(property, value) {
+    if (amplitudeHasInitialized) {
+      return RNAmplitudeSDK.appendToUserProperty(property, value);
+    } else {
+      throw new Error('You called Amplitude.appendToUserProperty before initializing it. Run new Amplitute(key) first.');
+    }
+  }
+
+  prependToUserProperty(property, value) {
+    if (amplitudeHasInitialized) {
+      return RNAmplitudeSDK.prependToUserProperty(property, value);
+    } else {
+      throw new Error('You called Amplitude.prependToUserProperty before initializing it. Run new Amplitute(key) first.');
     }
   }
 }

--- a/ios/AmplitudeSDK.m
+++ b/ios/AmplitudeSDK.m
@@ -111,4 +111,16 @@ RCT_EXPORT_METHOD(setUserPropertyOnce:(NSString *)property value:(NSString *)val
      [[Amplitude instance] identify:identify];
 }
 
+RCT_EXPORT_METHOD(appendToUserProperty:(NSString *)property value:(NSString *)value)
+{
+     AMPIdentify *identify = [[AMPIdentify identify] append:property value:value];
+     [[Amplitude instance] identify:identify];
+}
+
+RCT_EXPORT_METHOD(prependToUserProperty:(NSString *)property value:(NSString *)value)
+{
+     AMPIdentify *identify = [[AMPIdentify identify] prepend:property value:value];
+     [[Amplitude instance] identify:identify];
+}
+
 @end


### PR DESCRIPTION
Hello
I partially implemented 'append' and 'prepend' methods of amplitude's SDK
"partially" means that methods work correctly only with strings arguments, 
Sorry for that, but maybe even such a bad implementation will be useful to someone.
I have no good background and/or experience in Objective С or Java then i have really big problems with types.

I hope, somebody more experienced changes my code for other supported by SDK data types
